### PR TITLE
Parse token - structogram name

### DIFF
--- a/structogram_parser.go
+++ b/structogram_parser.go
@@ -5,6 +5,13 @@ import (
 	"strings"
 )
 
+type Token struct {
+	tokenType string
+	value     string
+	line      int
+	column    int
+}
+
 type Structogram struct {
 	name         string
 	instructions []string

--- a/structogram_parser.go
+++ b/structogram_parser.go
@@ -47,6 +47,14 @@ func parseTokens(tokens []Token) (ParsedObject, error) {
 			)
 		}
 		parsed.name = tokens[2].value
+	} else {
+		return parsed, errors.New(
+			fmt.Sprintf(
+				"%d:%d, structogram has to start with a name",
+				tokens[0].line,
+				tokens[0].column,
+			),
+		)
 	}
 	return parsed, err
 }

--- a/structogram_parser.go
+++ b/structogram_parser.go
@@ -28,6 +28,15 @@ func parseTokens(tokens []Token) (ParsedObject, error) {
 	var err error
 	if tokens[0].tokenType == "name" {
 		// The next token should be a openParentheses
+		if tokens[2].tokenType == "name" {
+			return parsed, errors.New(
+				fmt.Sprintf(
+					"%d:%d, names can not be nested",
+					tokens[2].line,
+					tokens[2].column,
+				),
+			)
+		}
 		if tokens[2].tokenType != "string" {
 			return parsed, errors.New(
 				fmt.Sprintf(

--- a/structogram_parser.go
+++ b/structogram_parser.go
@@ -17,6 +17,15 @@ type Structogram struct {
 	instructions []string
 }
 
+// TODO find a better name for this
+type ParsedObject struct {
+	name string
+}
+
+func parseTokens(tokens []Token) (ParsedObject, error) {
+	return ParsedObject{}, errors.New("1:5, missing name")
+}
+
 func parseToken(s, tokenStart, tokenEnd string) (content, remaining string) {
 	tokenStartIndex := strings.Index(s, tokenStart)
 	tokenEndIndex := strings.Index(s[tokenStartIndex:], tokenEnd) + tokenStartIndex

--- a/structogram_parser.go
+++ b/structogram_parser.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -23,7 +24,22 @@ type ParsedObject struct {
 }
 
 func parseTokens(tokens []Token) (ParsedObject, error) {
-	return ParsedObject{}, errors.New("1:5, missing name")
+	var parsed ParsedObject
+	var err error
+	if tokens[0].tokenType == "name" {
+		// The next token should be a openParentheses
+		if tokens[2].tokenType != "string" {
+			return parsed, errors.New(
+				fmt.Sprintf(
+					"%d:%d, missing name",
+					tokens[1].line,
+					tokens[1].column,
+				),
+			)
+		}
+		parsed.name = tokens[2].value
+	}
+	return parsed, err
 }
 
 func parseToken(s, tokenStart, tokenEnd string) (content, remaining string) {

--- a/structogram_parser_test.go
+++ b/structogram_parser_test.go
@@ -22,15 +22,36 @@ func checkErrorMsg(t *testing.T, err error, expectedMsg string) {
 }
 
 func TestStructogramHasToHaveAName(t *testing.T) {
+	// TODO Is this test still needed in this form if we are parsing tokens?
 	structogram, err := parseStructogram("has no name token")
 	_ = structogram
 	checkErrorMsg(t, err, "Structogram must have a name!")
 }
 
 func TestEmptyStructogramNameCausesError(t *testing.T) {
-	structogram, err := parseStructogram("name()")
-	_ = structogram
-	checkErrorMsg(t, err, "Structograms can not have empty names!")
+	// Represents the string 'name()'
+	tokens := []Token{
+		{
+			tokenType: "name",
+			value:     "name",
+			line:      1,
+			column:    1,
+		},
+		{
+			tokenType: "openParentheses",
+			value:     "(",
+			line:      1,
+			column:    5,
+		},
+		{
+			tokenType: "closeParentheses",
+			value:     ")",
+			line:      1,
+			column:    6,
+		},
+	}
+	_, err := parseTokens(tokens)
+	checkErrorMsg(t, err, "1:5, missing name")
 }
 
 func TestStructogramsHaveNames(t *testing.T) {

--- a/structogram_parser_test.go
+++ b/structogram_parser_test.go
@@ -55,8 +55,35 @@ func TestEmptyStructogramNameCausesError(t *testing.T) {
 }
 
 func TestStructogramsHaveNames(t *testing.T) {
+	// Represents the string 'name("test name")'
 	expectedName := "test name"
-	structogram, err := parseStructogram("name(" + expectedName + ")")
+	tokens := []Token{
+		{
+			tokenType: "name",
+			value:     "name",
+			line:      1,
+			column:    1,
+		},
+		{
+			tokenType: "openParentheses",
+			value:     "(",
+			line:      1,
+			column:    5,
+		},
+		{
+			tokenType: "string",
+			value:     "test name",
+			line:      1,
+			column:    6,
+		},
+		{
+			tokenType: "closeParentheses",
+			value:     ")",
+			line:      1,
+			column:    0,
+		},
+	}
+	structogram, err := parseTokens(tokens)
 	checkOk(t, err)
 
 	if structogram.name != expectedName {

--- a/structogram_parser_test.go
+++ b/structogram_parser_test.go
@@ -139,9 +139,59 @@ func TestNamesCanNotBeNested(t *testing.T) {
 }
 
 func TestNameHasToBeFirstToken(t *testing.T) {
-	structogram, err := parseStructogram("instruction(something)name(a name)")
-	_ = structogram
-	checkErrorMsg(t, err, "Structogram must have a name!")
+	// Represents the string '"instruction("something")name("a name")"'
+	tokens := []Token{
+		{
+			tokenType: "instruction",
+			value:     "instruction",
+			line:      1,
+			column:    1,
+		},
+		{
+			tokenType: "openParentheses",
+			value:     "(",
+			line:      1,
+			column:    12,
+		},
+		{
+			tokenType: "string",
+			value:     "something",
+			line:      1,
+			column:    13,
+		},
+		{
+			tokenType: "closeParentheses",
+			value:     ")",
+			line:      1,
+			column:    24,
+		},
+		{
+			tokenType: "name",
+			value:     "name",
+			line:      1,
+			column:    25,
+		},
+		{
+			tokenType: "openParentheses",
+			value:     "(",
+			line:      1,
+			column:    29,
+		},
+		{
+			tokenType: "string",
+			value:     "a name",
+			line:      1,
+			column:    30,
+		},
+		{
+			tokenType: "closeParentheses",
+			value:     ")",
+			line:      1,
+			column:    38,
+		},
+	}
+	_, err := parseTokens(tokens)
+	checkErrorMsg(t, err, "1:1, structogram has to start with a name")
 }
 
 func TestInstructionsCanNotBeEmpty(t *testing.T) {

--- a/structogram_parser_test.go
+++ b/structogram_parser_test.go
@@ -80,7 +80,7 @@ func TestStructogramsHaveNames(t *testing.T) {
 			tokenType: "closeParentheses",
 			value:     ")",
 			line:      1,
-			column:    0,
+			column:    17,
 		},
 	}
 	structogram, err := parseTokens(tokens)

--- a/structogram_parser_test.go
+++ b/structogram_parser_test.go
@@ -95,9 +95,47 @@ func TestStructogramsHaveNames(t *testing.T) {
 }
 
 func TestNamesCanNotBeNested(t *testing.T) {
-	structogram, err := parseStructogram("name(name())")
-	_ = structogram
-	checkErrorMsg(t, err, "Structogram names can not be nested!")
+	// Represents the string '"name(name())"'
+	tokens := []Token{
+		{
+			tokenType: "name",
+			value:     "name",
+			line:      1,
+			column:    1,
+		},
+		{
+			tokenType: "openParentheses",
+			value:     "(",
+			line:      1,
+			column:    5,
+		},
+		{
+			tokenType: "name",
+			value:     "name",
+			line:      1,
+			column:    6,
+		},
+		{
+			tokenType: "openParentheses",
+			value:     "(",
+			line:      1,
+			column:    11,
+		},
+		{
+			tokenType: "closeParentheses",
+			value:     ")",
+			line:      1,
+			column:    12,
+		},
+		{
+			tokenType: "closeParentheses",
+			value:     ")",
+			line:      1,
+			column:    13,
+		},
+	}
+	_, err := parseTokens(tokens)
+	checkErrorMsg(t, err, "1:6, names can not be nested")
 }
 
 func TestNameHasToBeFirstToken(t *testing.T) {


### PR DESCRIPTION
Instead of parsing a string, use tokens when parsing structogram names.